### PR TITLE
Add `Context` overloads to `AssertEx.Builder` chains

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 1.3.0
+
+* Minor: Added `Context` overloads to `AssertEx.Builder` chains
+* Patch: Remove dependencies on `Faithlife.Uitlity` and `System.Collections.Immutable`.
+
 ## 1.2.0
 
 * Added overload for `WaitForMessage` in `MessagePublishedAwaiter` that lets you pass in a custom timeout

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -3,7 +3,7 @@
 ## 1.3.0
 
 * Minor: Added `Context` overloads to `AssertEx.Builder` chains
-* Patch: Remove dependencies on `Faithlife.Uitlity` and `System.Collections.Immutable`.
+* Patch: Remove dependencies on `Faithlife.Utility` and `System.Collections.Immutable`.
 
 ## 1.2.0
 

--- a/src/Faithlife.Testing.RabbitMq/Faithlife.Testing.RabbitMq.csproj
+++ b/src/Faithlife.Testing.RabbitMq/Faithlife.Testing.RabbitMq.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Faithlife.Json" Version="0.7.0" />
-    <PackageReference Include="Faithlife.Utility" Version="0.10.1" />
     <PackageReference Include="Faithlife.WebRequests" Version="0.9.0" />
     <PackageReference Include="RabbitMQ.Client" Version="5.2.0" />
   </ItemGroup>

--- a/src/Faithlife.Testing.RabbitMq/MessagePublishedAwaiter.cs
+++ b/src/Faithlife.Testing.RabbitMq/MessagePublishedAwaiter.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Faithlife.Json;
-using Faithlife.Utility;
 using RabbitMQ.Client;
 using RabbitMQ.Client.MessagePatterns;
 
@@ -36,7 +35,7 @@ namespace Faithlife.Testing.RabbitMq
 
 			m_model = m_connection.CreateModel();
 
-			var queueName = $"{exchangeName}_{routingKeyName}_awaiter_{Environment.MachineName}_{Guid.NewGuid().ToLowerNoDashString()}";
+			var queueName = $"{exchangeName}_{routingKeyName}_awaiter_{Environment.MachineName}_{Guid.NewGuid():N}";
 			string queue = m_model.QueueDeclare(
 				queue: queueName,
 				durable: false,

--- a/src/Faithlife.Testing/AssemblyInfo.cs
+++ b/src/Faithlife.Testing/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Faithlife.Testing.Tests")]

--- a/src/Faithlife.Testing/AssertEx.cs
+++ b/src/Faithlife.Testing/AssertEx.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;

--- a/src/Faithlife.Testing/Faithlife.Testing.csproj
+++ b/src/Faithlife.Testing/Faithlife.Testing.csproj
@@ -10,9 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Faithlife.Json" Version="0.7.0" />
-    <PackageReference Include="Faithlife.Utility" Version="0.10.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Faithlife.Testing/ImmutableStack.cs
+++ b/src/Faithlife.Testing/ImmutableStack.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Faithlife.Testing
+{
+	internal sealed class ImmutableStack<T> : IEnumerable<T>
+	{
+		private ImmutableStack(T head, ImmutableStack<T> tail)
+		{
+			m_head = head;
+			m_tail = tail;
+		}
+
+		private ImmutableStack()
+		{
+		}
+
+#pragma warning disable CA1000 // Do not declare static members on generic types
+		public static ImmutableStack<T> Empty { get; } = new ImmutableStack<T>();
+#pragma warning restore CA1000 // Do not declare static members on generic types
+
+		public bool IsEmpty => m_tail == null;
+
+		public ImmutableStack<T> Push(T value) => new ImmutableStack<T>(value, this);
+
+		IEnumerator<T> IEnumerable<T>.GetEnumerator() => new Enumerator(this);
+
+		IEnumerator IEnumerable.GetEnumerator() => new Enumerator(this);
+
+		private sealed class Enumerator : IEnumerator<T>
+		{
+			public Enumerator(ImmutableStack<T> next)
+			{
+				m_next = next;
+			}
+
+			public bool MoveNext()
+			{
+				if (m_next.IsEmpty)
+					return false;
+
+				Current = m_next.m_head;
+				m_next = m_next.m_tail;
+				return true;
+			}
+
+			public void Reset() => throw new NotSupportedException();
+
+			public T Current { get; private set; }
+
+			object IEnumerator.Current => Current;
+
+			void IDisposable.Dispose()
+			{
+			}
+
+			private ImmutableStack<T> m_next;
+		}
+
+		private readonly T m_head;
+		private readonly ImmutableStack<T> m_tail;
+	}
+}

--- a/src/Faithlife.Testing/Scope.cs
+++ b/src/Faithlife.Testing/Scope.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Faithlife.Testing
+{
+	internal sealed class Scope : IDisposable
+	{
+		public static Scope Create(Action? dispose) => new Scope(dispose);
+
+		private Scope(Action? dispose)
+		{
+			m_dispose = dispose;
+		}
+
+		public void Dispose()
+		{
+			if (m_dispose is object)
+			{
+				m_dispose();
+				m_dispose = null;
+			}
+		}
+
+		private Action? m_dispose;
+	}
+}

--- a/tests/Faithlife.Testing.Tests/UnitTests/ContextTests.cs
+++ b/tests/Faithlife.Testing.Tests/UnitTests/ContextTests.cs
@@ -1,0 +1,109 @@
+using System;
+using NUnit.Framework;
+
+namespace Faithlife.Testing.Tests.UnitTests
+{
+	[TestFixture]
+	public sealed class ContextTests
+	{
+		[Test]
+		public void ObjectContext()
+		{
+			AssertHasNoContext();
+
+			using (AssertEx.Context(new { foo = "bar" }))
+				AssertHasContext("foo = \"bar\"");
+
+			AssertHasNoContext();
+		}
+
+		[Test]
+		public void NameValueContext()
+		{
+			AssertHasNoContext();
+
+			using (AssertEx.Context("foo", "bar"))
+				AssertHasContext("foo = \"bar\"");
+
+			AssertHasNoContext();
+		}
+
+		[Test]
+		public void ExpressionContext()
+		{
+			AssertHasNoContext();
+
+			var foo = "bar";
+			using (AssertEx.Context(() => foo))
+				AssertHasContext("foo = \"bar\"");
+
+			AssertHasNoContext();
+		}
+
+		[Test]
+		public void TupleContext()
+		{
+			AssertHasNoContext();
+
+			using (AssertEx.Context(("foo", "bar")))
+				AssertHasContext("foo = \"bar\"");
+
+			AssertHasNoContext();
+		}
+
+		[Test]
+		public void BuilderObjectContext() => AssertHasContext(b => b.Context(new { foo = "bar" }), "foo = \"bar\"");
+
+		[Test]
+		public void BuilderNameValueContext() => AssertHasContext(b => b.Context("foo", "bar"), "foo = \"bar\"");
+
+		[Test]
+		public void BuilderTupleContext() => AssertHasContext(b => b.Context(("foo", "bar")), "foo = \"bar\"");
+
+		[Test]
+		public void BuilderExpressionContext()
+		{
+			var foo = "bar";
+			AssertHasContext(b => b.Context(() => foo), "foo = \"bar\"");
+		}
+
+		private static void AssertHasNoContext()
+		{
+			var assertion = Assert.Throws<AssertionException>(() => AssertEx.Assert(() => false));
+			var expectedMessage = @"Expected:
+	false";
+			Assert.AreEqual(expectedMessage, assertion.Message, assertion.Message);
+		}
+
+		private static void AssertHasContext(string expectedContext)
+		{
+			var assertion = Assert.Throws<AssertionException>(() => AssertEx.Assert(() => false));
+			var expectedMessage = @"Expected:
+	false
+
+Context:
+	";
+			Assert.LessOrEqual(expectedMessage.Length, assertion.Message.Length, assertion.Message);
+			Assert.AreEqual(expectedMessage, assertion.Message.Substring(0, expectedMessage.Length), assertion.Message);
+			Assert.AreNotEqual(expectedMessage.Length, assertion.Message.Length, "Expected Context, got: " + expectedMessage);
+			Assert.AreEqual(expectedContext, assertion.Message.Substring(expectedMessage.Length), assertion.Message);
+		}
+
+		private static void AssertHasContext(Func<AssertEx.Builder<object>, AssertEx.Builder<object>> addContext, string expectedContext)
+		{
+			var builder = AssertEx.Select(new object());
+			builder = addContext(builder);
+
+			var assertion = Assert.Throws<AssertionException>(() => builder.Assert(o => false));
+			var expectedMessage = @"Expected:
+	false
+
+Context:
+	";
+			Assert.LessOrEqual(expectedMessage.Length, assertion.Message.Length, assertion.Message);
+			Assert.AreEqual(expectedMessage, assertion.Message.Substring(0, expectedMessage.Length), assertion.Message);
+			Assert.AreNotEqual(expectedMessage.Length, assertion.Message.Length, "Expected Context, got: " + expectedMessage);
+			Assert.AreEqual(expectedContext, assertion.Message.Substring(expectedMessage.Length), assertion.Message);
+		}
+	}
+}

--- a/tests/Faithlife.Testing.Tests/UnitTests/ImmutableStackTests.cs
+++ b/tests/Faithlife.Testing.Tests/UnitTests/ImmutableStackTests.cs
@@ -1,0 +1,17 @@
+using System.Linq;
+using NUnit.Framework;
+
+namespace Faithlife.Testing.Tests.UnitTests
+{
+	[TestFixture]
+	public sealed class ImmutableStackTests
+	{
+		[Test]
+		public void TestEnumerate()
+		{
+			var stack = ImmutableStack<string>.Empty.Push("foo");
+
+			Assert.AreEqual("foo", stack.Single());
+		}
+	}
+}


### PR DESCRIPTION
Also, remove dependencies on `Faithlife.Uitlity` and `System.Collections.Immutable` as the amount of code-duplication they relieve us of is far smaller than the cost they impose in version-conflicts.